### PR TITLE
prevent to start cam twice when changes appear

### DIFF
--- a/src/ngx-zxing.component.ts
+++ b/src/ngx-zxing.component.ts
@@ -53,14 +53,7 @@ export class NgxZxingComponent implements AfterViewInit, OnDestroy, OnChanges {
     }
 
     ngOnChanges(changes: SimpleChanges): void {
-        if (changes.start) {
-            if (this.start) {
-                this.startCam();
-            } else {
-                this.stopCam();
-            }
-        }
-        if (changes.device && this.device) {
+        if ((changes.start || changes.device) && this.device) {
             this.stopCam();
             this.deviceId = this.device.deviceId;
             if (this.start) {


### PR DESCRIPTION
Due to changes in the ng component the start flag as well as the devices changed - therefore the cam is started twice. 
But since the stream is not initialized yet the stopCam function isn't doing anything which results in starting the cam twice (stream not closed properly) and creating a DOM exception:
"Uncaught (in promise) DOMException: The play() request was interrupted by a new load request."

This fix prevents starting the cam twice. But I'm not sure if there would be a better solution (e.g. directly when opening the stream or waiting for a callback when stream is opened).